### PR TITLE
Request error handling and timeout

### DIFF
--- a/package/contents/code/covid.js
+++ b/package/contents/code/covid.js
@@ -58,10 +58,13 @@ function getRate(source, country, callback) {
 	
 	if(source === null) return false;
 	request(source.url, source.method, source.requestBody, function(data) {	
-		if(data.length === 0) return false;
-		data = JSON.parse(data);
-		var rate = source.getRate(data, country);
-		callback(rate);
+		try {
+			data = JSON.parse(data);
+			var rate = source.getRate(data, country);
+			callback(rate);
+		} catch (e) {
+			callback(null);
+		}
 	});
 	
 	return true;

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -33,5 +33,8 @@
       <label>Show background</label>
       <default>true</default>
     </entry>
+    <entry name="rate" type="int">
+      <default>0</default>
+    </entry>
   </group>
 </kcfg>

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -118,6 +118,18 @@ Item {
 		}
 	}
 	
+	function setRate(rate) {
+		var rateText = (rate === null ? plasmoid.configuration.rate : Number(rate));
+		plasmoid.configuration.rate = rateText;
+		root.covidCases = rateText;
+		
+		var toolTipSubText = '<b>' + root.covidCases + '</b>';
+		toolTipSubText += '<br />';
+		toolTipSubText += i18n('Source:') + ' ' + plasmoid.configuration.source;
+		
+		plasmoid.toolTipSubText = toolTipSubText;
+	}
+	
 	Timer {
 		id: refreshTimer
 		interval: plasmoid.configuration.refreshRate * 60 * 1000
@@ -126,21 +138,23 @@ Item {
 		triggeredOnStart: true
 		onTriggered: {
 			root.updatingRate = true;
+			refreshTimeout.start();
 			
 			var result = Covid.getRate(plasmoid.configuration.source, plasmoid.configuration.country, function(rate) {
-				
-				var rateText = Number(rate);
-				
-				root.covidCases = rateText;
-				
-				var toolTipSubText = '<b>' + root.covidCases + '</b>';
-				toolTipSubText += '<br />';
-				toolTipSubText += i18n('Source:') + ' ' + plasmoid.configuration.source;
-				
-				plasmoid.toolTipSubText = toolTipSubText;
-				
+				setRate(rate);
 				root.updatingRate = false;
+				refreshTimeout.stop();
 			});
+		}
+	}
+	
+	Timer {
+		id: refreshTimeout
+		interval: 30000
+		repeat: false
+		onTriggered: {
+			setRate(null);
+			root.updatingRate = false
 		}
 	}
 	


### PR DESCRIPTION
Currently the applet will show busy indicator indefinitely when offline or if the service is down. This pull request will add error handling and timeout. Timeout is set to 30 second and will display previous rate on error or timeout.